### PR TITLE
using reakit and theme ui as peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex-components/button",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1",
   "description": "VTEX button component",
   "author": "vtex",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex-components/button",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.0",
   "description": "VTEX button component",
   "author": "vtex",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   },
   "sideEffects": false,
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0",
+    "reakit": "^1.1.2",
+    "theme-ui": "^0.3.1"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^5.3.19",
@@ -48,12 +50,10 @@
     "react-docgen-typescript-loader": "^3.7.2",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.1",
+    "reakit": "^1.1.2",
+    "theme-ui": "^0.3.1",
     "ts-loader": "^8.0.1",
     "tsdx": "^0.13.2",
     "typescript": "^3.9.6"
-  },
-  "dependencies": {
-    "reakit": "^1.1.2",
-    "theme-ui": "^0.3.1"
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add reakit and theme UI as peer

#### What problem is this solving?
currently the install theme-ui button and reakit as a dependency, but it must be installed as a peer dependencies (to have to be installed in the parent repository) and dev dependency (so you can test it in the storybook)

That way we decrease from 11MB to 21kb

![Screen Shot 2020-07-27 at 19 21 14](https://user-images.githubusercontent.com/10627086/88597768-5a508e80-d03e-11ea-8573-a2154be28887.png)

![Screen Shot 2020-07-27 at 19 26 14](https://user-images.githubusercontent.com/10627086/88598154-0d20ec80-d03f-11ea-8051-d4bd4bb5fe1d.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly
