### PR TITLE
Allow Button to use reakit's composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ yarn add reakit theme-ui
 
 ```tsx
 import React from 'react'
-import Button from '@vtex-component/button'
+import Button from '@vtex-components/button'
 
 function Example() {
   return <Button>Button Label</Button>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex-components/button",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "VTEX button component",
   "author": "vtex",
   "license": "MIT",

--- a/src/Button.stories.tsx
+++ b/src/Button.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { ThemeProvider } from 'theme-ui'
 import { withA11y } from '@storybook/addon-a11y'
 import { withKnobs, text, color, boolean } from '@storybook/addon-knobs'
+import { Checkbox, useCheckboxState } from 'reakit'
 
 import Button from '.'
 
@@ -42,6 +43,26 @@ export function TheSXProp() {
     >
       Base Button
     </Button>
+  )
+}
+
+export function TheAsProp() {
+  const checkbox = useCheckboxState()
+
+  return (
+    <ThemeProvider
+      theme={{
+        colors: {
+          background: '#FFFFFF',
+          primary: '#2F323A',
+          secondary: '#4F5D75',
+        },
+      }}
+    >
+      <Checkbox {...checkbox} as={Button}>
+        {checkbox.state ? '😄 Happy' : '😞 Sad'}
+      </Checkbox>
+    </ThemeProvider>
   )
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,8 +7,8 @@ import {
 
 type Props = A11yProps & ThemeAwareProps
 
-function Button(props: Props, ref: Ref<HTMLButtonElement>) {
-  return <A11yButton {...props} ref={ref} as={ThemeAwareButton} />
+function Button({ as, ...props }: Props, ref: Ref<HTMLButtonElement>) {
+  return <A11yButton {...props} ref={ref} as={as ?? ThemeAwareButton} />
 }
 
 export { A11yProps, ThemeAwareProps }


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says

#### What problem is this solving?
We may need the `as` prop to allow composition.

#### How should this be manually tested?
Clone the repo and `yarn && yarn start`

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [x] Requires change to documentation, which has been updated accordingly
