### PR TITLE
Support inference extra props from as props

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.1",
     "reakit": "^1.1.2",
+    "reakit-utils": "^0.13.1",
     "theme-ui": "^0.3.1",
     "ts-loader": "^8.0.1",
     "tsdx": "^0.13.2",

--- a/src/Button.stories.tsx
+++ b/src/Button.stories.tsx
@@ -1,8 +1,7 @@
-import React from 'react'
+import React, { useReducer, useRef, useEffect, forwardRef, Ref } from 'react'
 import { ThemeProvider } from 'theme-ui'
 import { withA11y } from '@storybook/addon-a11y'
 import { withKnobs, text, color, boolean } from '@storybook/addon-knobs'
-import { Checkbox, useCheckboxState } from 'reakit'
 
 import Button from '.'
 
@@ -46,8 +45,16 @@ export function TheSXProp() {
   )
 }
 
-export function TheAsProp() {
-  const checkbox = useCheckboxState()
+export function TheAsPropWithIntrinsicElement() {
+  const ref = useRef<HTMLAnchorElement>(null)
+  const [checked, toggle] = useReducer((value) => !value, false)
+
+  useEffect(() => {
+    console.warn(
+      `TheAsPropWithIntrinsicElement: Detects properly type of \`ref\` from \`as\``,
+      ref.current
+    )
+  }, [])
 
   return (
     <ThemeProvider
@@ -59,9 +66,48 @@ export function TheAsProp() {
         },
       }}
     >
-      <Checkbox {...checkbox} as={Button}>
-        {checkbox.state ? '😄 Happy' : '😞 Sad'}
-      </Checkbox>
+      <Button ref={ref} as="a" target="_blank" onClick={toggle}>
+        {checked ? '😄 Happy' : '😞 Sad'}
+      </Button>
+    </ThemeProvider>
+  )
+}
+
+const Link = forwardRef(function Link(
+  { children, ...props }: JSX.IntrinsicElements['a'],
+  ref: Ref<HTMLAnchorElement>
+) {
+  return (
+    <a ref={ref} {...props}>
+      {children}
+    </a>
+  )
+})
+
+export function TheAsPropWithCustomElement() {
+  const ref = useRef<HTMLAnchorElement>(null)
+  const [checked, toggle] = useReducer((value) => !value, false)
+
+  useEffect(() => {
+    console.warn(
+      `TheAsPropWithCustomElement: Detects properly type of \`ref\` from \`as\``,
+      ref.current
+    )
+  }, [])
+
+  return (
+    <ThemeProvider
+      theme={{
+        colors: {
+          background: '#FFFFFF',
+          primary: '#2F323A',
+          secondary: '#4F5D75',
+        },
+      }}
+    >
+      <Button ref={ref} as={Link} target="_blank" onClick={toggle}>
+        {checked ? '😄 Happy' : '😞 Sad'}
+      </Button>
     </ThemeProvider>
   )
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,15 +1,29 @@
-import React, { forwardRef, Ref } from 'react'
+import React, { forwardRef, Ref, PropsWithoutRef } from 'react'
 import { Button as A11yButton, ButtonProps as A11yProps } from 'reakit'
+import { PropsWithAs, As } from 'reakit-utils/types'
 import {
   Button as ThemeAwareButton,
   ButtonProps as ThemeAwareProps,
 } from 'theme-ui'
 
-type Props = A11yProps & ThemeAwareProps
-
-function Button({ as, ...props }: Props, ref: Ref<HTMLButtonElement>) {
-  return <A11yButton {...props} ref={ref} as={as ?? ThemeAwareButton} />
+type Component<DefaultAs extends As, DefaultProps> = {
+  <T extends As = DefaultAs>(
+    props: PropsWithAs<PropsWithoutRef<DefaultProps>, T>
+  ): JSX.Element
 }
 
-export { A11yProps, ThemeAwareProps }
-export default forwardRef(Button)
+type ButtonProps = A11yProps & { as?: As }
+
+const Button = (
+  { as = ThemeAwareButton, ...props }: ButtonProps,
+  ref: Ref<As>
+) => {
+  return <A11yButton ref={ref} as={as} {...props} />
+}
+
+export { ButtonProps, A11yProps, ThemeAwareProps }
+
+export default forwardRef(Button) as Component<
+  typeof ThemeAwareButton,
+  A11yProps
+>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,21 +1,15 @@
-import React, { forwardRef, Ref, PropsWithoutRef } from 'react'
+import React, { forwardRef, Ref } from 'react'
 import { Button as A11yButton, ButtonProps as A11yProps } from 'reakit'
-import { PropsWithAs, As } from 'reakit-utils/types'
 import {
   Button as ThemeAwareButton,
   ButtonProps as ThemeAwareProps,
 } from 'theme-ui'
+import { As, Props, Component } from '@vtex-components/types'
 
-type Component<DefaultAs extends As, DefaultProps> = {
-  <T extends As = DefaultAs>(
-    props: PropsWithAs<PropsWithoutRef<DefaultProps>, T>
-  ): JSX.Element
-}
-
-type ButtonProps = A11yProps & { as?: As }
+type ButtonProps<T extends As = typeof ThemeAwareButton> = Props<T, A11yProps>
 
 const Button = (
-  { as = ThemeAwareButton, ...props }: ButtonProps,
+  { as = ThemeAwareButton, ...props }: ButtonProps<As>,
   ref: Ref<As>
 ) => {
   return <A11yButton ref={ref} as={as} {...props} />
@@ -23,7 +17,4 @@ const Button = (
 
 export { ButtonProps, A11yProps, ThemeAwareProps }
 
-export default forwardRef(Button) as Component<
-  typeof ThemeAwareButton,
-  A11yProps
->
+export default forwardRef(Button) as Component<ButtonProps>

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -15,3 +15,27 @@ declare module '*.svg' {
   export default svgUrl
   export { svgComponent as ReactComponent }
 }
+
+declare module '@vtex-components/types' {
+  import { PropsWithoutRef } from 'react'
+  import { As, PropsWithAs } from 'reakit-utils/types'
+
+  export { As }
+
+  export type Props<T extends As, BaseProps> = PropsWithAs<
+    PropsWithoutRef<BaseProps>,
+    T
+  >
+
+  export type AsOf<T> = T extends Props<infer TAs, any> ? TAs : never
+
+  export type BasePropsOf<T> = T extends Props<any, infer TProps>
+    ? TProps
+    : never
+
+  export type Component<DefaultProps extends Props<any, any>> = {
+    <T extends As = AsOf<DefaultProps>>(
+      props: Props<T, BasePropsOf<DefaultProps>>
+    ): JSX.Element
+  }
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add support to merge props from the component passed in prop `as`.

#### What problem is this solving?
Correct type detection of new props when `as` is passed.

#### How should this be manually tested?
The examples of `Button.stories.tsx` could have correct type.

1. The example `Checkbox` has changed to compose `Button` with `a` and `Link`, instead compose `Checkbox` with `Button`, so the props of `a` and `Link` must be merged with the `Button` in this cases.
2. The examples without defining `as` should merge the props of `ThemeAwareButton` by default.

#### Screenshots or example usage

Before:

![Screenshot from 2020-07-29 16-01-56](https://user-images.githubusercontent.com/8618687/88842457-dde0bb80-d1b5-11ea-87df-48e4886a9a53.png)

After: 
![Screenshot from 2020-07-29 16-02-40](https://user-images.githubusercontent.com/8618687/88842460-dfaa7f00-d1b5-11ea-9595-d0798eb9e256.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media1.giphy.com/media/SiNGhMu9W4180gvZk5/200w.webp?cid=ecf05e4768fbbeb0a4a95e26e062a436f40ce1d69979ae35&rid=200w.webp)


### Notes

I need to cast the return of `forwardRef`, because `forwardRef` [don't pass the generics forward](https://github.com/reakit/reakit/issues/649#issuecomment-630403660).